### PR TITLE
Add Chinese documentation for Coder class execution flow

### DIFF
--- a/coder_execution_flow_zh.md
+++ b/coder_execution_flow_zh.md
@@ -1,0 +1,336 @@
+# Aider Coder 类执行流程分析
+
+## `Coder.create` 类方法分析
+
+`Coder.create` 方法是一个工厂类方法，负责根据提供的 `edit_format` 参数（编辑格式）创建不同类型的 Coder 实例。
+
+**主要功能:**
+
+1.  **选择 Coder 类:**
+    *   根据传入的 `edit_format` 参数，在 `aider.coders` 模块中查找具有匹配 `edit_format` 属性的 Coder 子类。
+    *   例如，如果 `edit_format` 是 `"diff"`，它会选择 `DiffCoder`。
+2.  **初始化参数准备:**
+    *   **`main_model`**: 主要的语言模型（LLM）实例。如果未提供，则会尝试从 `from_coder` (如果提供) 或默认模型 (`models.DEFAULT_MODEL_NAME`) 中获取。
+    *   **`edit_format`**: 编辑格式。如果未提供或为 `"code"` (视为默认)，则会尝试从 `from_coder` 或 `main_model` 的默认编辑格式中获取。
+    *   **`io`**: 输入输出处理器 (`InputOutput` 类的实例)。如果未提供且有 `from_coder`，则使用 `from_coder.io`。
+    *   **`from_coder`**: 可选的现有 Coder 实例。如果提供此参数，新的 Coder 实例可以继承 `from_coder` 的某些属性和聊天记录。
+    *   **`summarize_from_coder`**: 布尔值，默认为 `True`。当从 `from_coder` 创建并且 `edit_format` 发生改变时，如果为 `True`，则会尝试总结 `from_coder` 的聊天记录。
+    *   **`**kwargs`**: 其他关键字参数，会传递给选定的 Coder 子类的构造函数。
+3.  **处理 `from_coder` (如果提供):**
+    *   复制 `from_coder.original_kwargs` (原始初始化参数) 作为新实例参数的基础。
+    *   如果 `edit_format` 与 `from_coder.edit_format` 不同，并且 `summarize_from_coder` 为 `True`，则会尝试通过 `from_coder.summarizer.summarize_all()` 总结 `from_coder.done_messages` (已完成的聊天记录)。如果总结失败，会发出警告并使用完整的历史记录。
+    *   将 `from_coder` 的多个核心属性（如 `fnames`, `read_only_fnames`, `done_messages`, `cur_messages`, `aider_commit_hashes`, `commands`, `total_cost`, `ignore_mentions`, `total_tokens_sent`, `total_tokens_received`, `file_watcher` 等）更新到待传递给新实例的参数字典中。
+    *   这些继承的参数会被显式传入 `create` 方法的 `**kwargs` 所覆盖。
+    *   设置 `from_coder.ok_to_warm_cache = False`，以防止旧实例继续预热缓存。
+4.  **实例化 Coder:**
+    *   使用准备好的参数（`main_model`, `io`, 以及合并后的 `kwargs`）来实例化选定的 Coder 子类。
+    *   将最终用于初始化的 `kwargs` 存储在新创建的 Coder 实例的 `original_kwargs` 属性中。
+5.  **错误处理:**
+    *   如果在 `aider.coders.__all__` (所有可用的 Coder 类列表) 中找不到与 `edit_format` 匹配的 Coder 类，则会抛出 `UnknownEditFormat` 异常，并列出所有有效的 `edit_format`。
+
+**总结:**
+
+`Coder.create` 方法充当了一个 Coder 实例的工厂。它根据 `edit_format` 动态选择合适的 Coder 实现，并负责整合所有必要的配置参数（包括从现有 Coder 实例继承状态）。这种设计使得 Aider 系统可以灵活地支持和切换不同的代码编辑与交互策略。
+
+## Coder 类初始化 (`__init__`)
+
+`Coder` 类的初始化方法 `__init__` 负责设置 Coder 实例的基本环境和各项配置。
+
+主要步骤包括：
+
+1.  **设置核心属性**:
+    *   `io`: `InputOutput` 实例，用于与用户交互。
+    *   `repo`: `GitRepo` 实例，用于版本控制和文件管理。如果 `use_git` 为 `True` (默认) 且当前目录是 Git 仓库，则会自动初始化。
+    *   `main_model`: 主要的 LLM 实例。
+    *   `fnames`: 用户指定需要处理的文件路径列表。
+    *   `read_only_fnames`: 只读文件路径列表。
+    *   其他配置参数如 `show_diffs` (显示差异), `auto_commits` (自动提交), `dry_run` (空运行模式) 等。
+    *   `abs_fnames`: 存储处理后文件的绝对路径集合。
+    *   `abs_read_only_fnames`: 存储处理后只读文件的绝对路径集合。
+
+2.  **处理文件 (`fnames` 和 `read_only_fnames`)**:
+    *   **对于 `fnames`**:
+        *   遍历列表中的每个文件路径：
+            *   检查文件是否被 `gitignore` 或 `.aiderignore` (Aider 的忽略文件) 规则所忽略。如果被忽略，则警告并跳过。
+            *   如果文件不存在，尝试创建空文件。如果创建失败，则警告并跳过。
+            *   如果路径不是普通文件（例如是目录），则警告并跳过。
+            *   将有效文件的绝对路径添加到 `self.abs_fnames` 集合中。
+            *   调用 `self.check_added_files()` 检查添加的文件数量和总 token 数是否过多，并给出警告。
+    *   **确定根目录 (`self.root`)**:
+        *   如果存在 `GitRepo` 实例 (`self.repo`)，则使用仓库的根目录作为 `self.root`。
+        *   否则，根据 `self.abs_fnames` 中的文件路径推断它们的共同父目录作为 `self.root`。
+    *   **对于 `read_only_fnames`**:
+        *   类似地处理只读文件列表，将有效文件的绝对路径添加到 `self.abs_read_only_fnames`。
+
+3.  **初始化仓库地图 (`RepoMap`)**:
+    *   `RepoMap` 用于生成代码库的概要信息（“地图”），帮助 LLM 理解项目结构，尤其是在处理大型仓库时。
+    *   如果 `use_repo_map` (通常通过 `map_tokens > 0` 判断) 为 `True` 且 `self.repo` 存在，则创建 `RepoMap` 实例。
+    *   `map_tokens` 控制仓库地图的token预算。
+
+4.  **恢复聊天记录**:
+    *   如果 `done_messages` (已完成的聊天消息列表) 为空且 `restore_chat_history` (恢复聊天记录) 为 `True`：
+        *   尝试从 `self.io.chat_history_file` (通常是 `.aider.chat.history.md`) 读取之前保存的聊天记录。
+        *   如果读取成功，将 Markdown 格式的聊天记录分割成消息对象，并启动总结线程 (`self.summarize_start()`) 对过长的历史记录进行总结。
+
+5.  **设置 Linter 和测试命令**:
+    *   初始化 `Linter` 对象，用于后续的代码规范检查。
+    *   根据用户配置 (`lint_cmds`, `auto_lint`, `test_cmd`, `auto_test`) 设置自动 lint 和自动测试的相关命令和行为。
+
+## 主执行循环 (`run`)
+
+`run` 方法是 Coder 类与用户进行持续交互的主循环。
+
+主要流程如下：
+
+1.  **处理初始消息 (可选)**:
+    *   如果调用 `run` 方法时提供了 `with_message` 参数 (通常来自命令行参数 `-m "message"`):
+        *   通过 `self.io.user_input(with_message)` 将该消息显示给用户（模拟用户输入行为）。
+        *   调用 `self.run_one(with_message, preproc=True)` 处理这条初始消息。`preproc` 参数表示需要进行预处理。
+        *   处理完毕后，返回 LLM 生成的部分响应内容 `self.partial_response_content`。
+
+2.  **持续交互循环**:
+    *   如果没有提供 `with_message`，或者初始消息处理完毕后，程序进入一个无限循环，等待用户输入新的指令或消息。
+    *   **上下文复制**: 在每次循环等待用户输入之前，如果 `self.io.placeholder` 为空（意味着不是在等待多行输入的中间状态），会调用 `self.copy_context()`。如果 `self.auto_copy_context` (自动复制上下文) 配置为 `True`，该方法会执行 `/copy` 命令的逻辑，尝试将系统剪贴板的内容作为上下文添加到聊天中。
+    *   **获取用户输入**: 调用 `self.get_input()` 获取用户输入。此方法会向用户显示输入提示符，并处理用户的命令 (如 `/add`, `/run`) 或发送给 LLM 的自然语言消息。
+        *   `get_input` 会向用户展示当前聊天中的文件列表、可供添加到聊天的文件列表等上下文信息，以便用户更好地发出指令。
+    *   **处理单条消息**: 调用 `self.run_one(user_message, preproc=True)` 处理用户输入的消息。
+    *   **撤销提示**: 处理完消息后，调用 `self.show_undo_hint()`。如果 Aider 在处理消息过程中进行了 Git 提交，此方法会提示用户可以使用 `/undo` 命令来撤销这些提交。
+
+3.  **异常处理**:
+    *   **`KeyboardInterrupt` (Ctrl+C)**:
+        *   第一次按下 Ctrl+C，会提示用户再次按下以确认退出。
+        *   如果在短时间内连续两次按下 Ctrl+C，程序将退出。
+    *   **`EOFError` (Ctrl+D 或输入流结束)**:
+        *   当捕获到 `EOFError` 时，表示用户输入结束（例如，通过管道传递输入完毕，或用户在提示符下按了 Ctrl+D），`run` 方法正常返回，主循环结束。
+
+## 单条消息处理 (`run_one`)
+
+`run_one` 方法负责处理单条用户消息的完整流程，从接收用户输入到获取并处理 LLM 的响应，包括可能的反思修正。
+
+主要步骤如下：
+
+1.  **消息处理前初始化 (`init_before_message`)**:
+    *   在处理每条新消息之前，此方法会重置一系列与单次消息相关的状态变量：
+        *   `self.aider_edited_files`: 清空 Aider 在本次交互中已编辑过的文件路径集合。
+        *   `self.reflected_message`: 清空用于“反思”的消息内容。反思消息是当 LLM 的上一次尝试（如代码编辑、lint修复）失败后，系统生成并反馈给 LLM 以引导其进行自我修正的消息。
+        *   `self.num_reflections`: 重置当前消息的反思次数计数器。
+        *   `self.lint_outcome`, `self.test_outcome`: 清空上一次 lint 和测试的结果状态。
+        *   `self.shell_commands`: 清空由 LLM 在上一次响应中建议的 shell 命令列表。
+        *   `self.message_cost`: 重置本次消息交互所产生的费用。
+    *   如果项目使用了 Git 仓库 (`self.repo` 存在)，则将当前 HEAD 的 commit hash 添加到 `self.commit_before_message` 列表中。这用于后续判断 Aider 是否因本次消息处理而创建了新的 commit。
+
+2.  **用户输入预处理 (`preproc_user_input`)**:
+    *   如果 `preproc` 参数为 `True` (通常是这种情况)，则对用户输入的原始消息 `user_message` 进行预处理：
+        *   **命令检查**: 使用 `self.commands.is_command(inp)` 判断输入是否为 Aider 的内置命令 (如 `/add <file>`, `/drop <file>`, `/run <shell_command>`, `/undo` 等)。
+            *   如果是命令，则调用 `self.commands.run(inp)` 执行该命令，并返回命令的输出结果（如果有的话）。在这种情况下，消息通常不会发送给 LLM，`run_one` 的后续流程可能被跳过或修改。
+        *   **文件提及检查 (`check_for_file_mentions`)**: 扫描输入内容，查找是否存在可能是文件名的文本。
+            *   如果找到未被用户忽略且尚未添加到聊天上下文中的文件名，会提示用户是否要将这些文件添加到聊天中（即加入到 `self.abs_fnames`）。
+        *   **URL 检查 (`check_for_urls`)**: 如果 `self.detect_urls` (检测URL) 配置为 `True`，扫描输入内容中的 URL。
+            *   对于每个找到的 URL，如果用户确认，会通过 `/web <url>` 命令的逻辑获取该 URL 指向的网页内容，并将内容附加到当前用户消息中，以便 LLM 可以处理这些信息。
+    *   预处理后的消息（可能已经追加了文件内容或 URL 内容）将作为 `message` 用于后续处理。如果输入是命令且命令已经执行完毕并返回了结果，那么 `message` 可能为 `None` 或命令的直接输出。
+
+3.  **消息发送与反思循环**:
+    *   只要 `message` 不为空 (即有内容需要发送给 LLM 或进行反思)：
+        *   将 `self.reflected_message` 重置为 `None`。
+        *   调用 `self.send_message(message)` 将当前 `message` 发送给 LLM 并获取响应。此步骤的详细流程见下一节。
+        *   **反思机制 (Reflection)**:
+            *   在 `send_message` 执行完毕后，如果 `self.reflected_message` 被赋予了新的内容（这通常发生在代码应用失败、lint 检查发现错误、或测试未通过时，系统会生成一段描述问题的文本作为反思消息），则表明需要进行反思。
+            *   检查当前反思次数 `self.num_reflections` 是否已达到最大限制 `self.max_reflections`。
+                *   如果未达到限制：增加 `self.num_reflections`，并将 `self.reflected_message` 的内容赋给 `message`，然后循环继续，再次调用 `self.send_message`，此时 LLM 会接收到这个反思消息并尝试修正其之前的行为。
+                *   如果已达到最大反思次数，会向用户发出警告，并停止针对此用户消息的进一步反思，以避免无限循环。此时 `message` 会被置为 `None`，从而跳出循环。
+            *   如果 `self.reflected_message` 在 `send_message` 后仍为 `None` (表示 LLM 的响应被成功处理，或没有触发需要反思的错误)，则 `message` 被置为 `None`，循环终止。
+
+## 发送消息给 LLM (`send_message`)
+
+`send_message` 方法是与语言模型（LLM）交互的核心环节，负责构建完整的上下文（prompt），发送请求，并处理 LLM 返回的响应。
+
+主要步骤如下：
+
+1.  **更新当前消息列表**:
+    *   将用户当前的输入 `inp` (作为参数传入此方法) 包装成一个消息对象 `dict(role="user", content=inp)`，并将其追加到 `self.cur_messages` (当前对话消息列表) 中。
+
+2.  **格式化消息 (`format_messages`)**:
+    *   调用 `self.format_messages()` 来构建最终发送给 LLM 的完整消息列表。这是一个复杂但关键的过程，涉及到多种上下文信息的动态组装：
+        *   **选择代码围栏 (Fence)**: 调用 `self.choose_fence()` 根据当前聊天文件内容，智能选择合适的代码块包围符号 (例如，如果文件内容中已有 ` ``` `，则可能选择 ` ```` ```` ` 作为围栏)，以避免与文件内容冲突。结果存储在 `self.fence`。
+        *   **系统提示 (`system_prompt`)**:
+            *   基于 `self.gpt_prompts.main_system` 构建主系统提示。此提示包含了对 LLM 行为的总括性指导，如其角色、任务、输出格式要求（特别是代码编辑格式）、代码围栏的使用、当前平台信息（操作系统、shell类型、日期、是否在Git仓库内）、用户偏好的 lint/test 命令等。
+            *   如果 `self.main_model.system_prompt_prefix` (模型特定的系统提示前缀) 存在，则将其附加到主系统提示之前。
+            *   如果模型配置要求将示例对话作为系统消息的一部分 (`self.main_model.examples_as_sys_msg` 为 `True`)，则会将 `self.gpt_prompts.example_messages` 中的示例对话也格式化并整合进系统提示。
+        *   **示例消息 (`example_messages`)**:
+            *   如果模型不要求示例作为系统消息，则将 `self.gpt_prompts.example_messages` 中的示例对话格式化为独立的用户和助手消息对。
+        *   **聊天记录 (`done_messages`)**:
+            *   包含当前会话中已经完成的对话轮次（用户输入和 LLM 回复）。在整合前，会调用 `self.summarize_end()` 确保任何正在进行的聊天记录异步总结任务已完成，并使用总结后的聊天记录（如果适用）。
+        *   **仓库地图 (`repo_map`)**:
+            *   调用 `self.get_repo_map()` 获取当前项目的代码仓库概要信息。此信息可以帮助 LLM 理解项目中其他文件的存在和大致结构，即使这些文件没有被显式添加到聊天中。
+        *   **只读文件内容 (`read_only_files`)**:
+            *   调用 `self.get_readonly_files_messages()` 获取所有只读文件 (`self.abs_read_only_fnames`) 的内容，并将其格式化为特定的用户消息。
+        *   **聊天文件内容 (`chat_files`)**:
+            *   调用 `self.get_chat_files_messages()` 获取当前聊天中已添加的可编辑文件 (`self.abs_fnames`) 的内容，并将其格式化为特定的用户消息。
+        *   **当前对话 (`cur_messages`)**: 包含了用户最新的输入（已在本方法开始时添加）。
+        *   **提醒消息 (`reminder_message`)**:
+            *   如果配置了 `self.gpt_prompts.system_reminder` (一个简短的提醒，通常重复关键的指令格式)，并且当前构建的上下文 token 总量加上提醒消息的 token 量未超过模型限制，则会添加这个提醒消息。其角色（`system` 或 `user`）取决于模型配置。
+        *   所有这些部分被组织成一个 `ChatChunks` 对象，该对象负责管理不同类型的消息块，并最终通过其 `all_messages()` 方法合并成一个单一的、有序的 `messages` 列表，准备发送给 LLM。
+        *   如果 `self.add_cache_headers` (添加缓存头) 为 `True`，`ChatChunks` 会为可缓存的消息块（如系统提示、文件内容等）添加缓存控制相关的头信息，以便利用如 Deepseek Coder 等模型的提示缓存功能。
+
+3.  **Token 数量检查 (`check_tokens`)**:
+    *   使用 `self.main_model.token_count(messages)` 计算格式化后的 `messages` 列表的总 token 数量。
+    *   如果计算出的 `input_tokens` 大于或等于模型的最大输入 token 限制 (`self.main_model.info.get("max_input_tokens")`)，会向用户显示错误信息，解释 token 超限的风险，并提供减少 token 的建议 (如 `/drop` 文件，`/clear` 历史等)。然后会询问用户是否仍要尝试发送。如果用户选择否，则中止发送流程。
+
+4.  **缓存预热 (`warm_cache`)**:
+    *   如果启用了提示缓存 (`self.add_cache_headers`) 并且配置了预热次数 (`self.num_cache_warming_pings > 0`) 且当前 Coder 实例允许预热 (`self.ok_to_warm_cache`)，则会调用此方法。
+    *   它会启动一个后台线程，定期向模型发送包含可缓存部分的“预热”请求（通常是 `max_tokens=1` 的请求），目的是让模型的提示缓存保持“温暖”状态，提高后续真实请求的缓存命中率。
+
+5.  **调用 LLM (`self.send`)**:
+    *   实际的 LLM API 调用发生在 `self.send(messages, functions=self.functions)` 方法内。此方法内部会调用 `self.main_model.send_completion()`，后者是对 `litellm.completion()` 的封装。
+    *   `functions` 参数允许传递给 LLM 一组可供其调用的工具的 schema (如果模型支持函数调用/工具使用)。
+    *   **流式输出 (`self.stream` 为 `True`)**:
+        *   如果启用了流式输出且模型支持，`model.send_completion()` 会返回一个生成器 (`completion`)。
+        *   `self.show_send_output_stream(completion)` 会迭代处理从生成器中接收到的每个响应 `chunk`。
+        *   对于每个 `chunk`，它会提取 `delta` (变化量)，其中可能包含文本内容 (`content`)、函数调用信息 (`function_call`) 或推理内容 (`reasoning_content`)。这些增量内容会被追加到相应的内部变量 (`self.partial_response_content`, `self.partial_response_function_call`)。
+        *   如果启用了“漂亮”输出 (`self.show_pretty()`)，会通过 `self.mdstream` (一个 Markdown 流处理器) 实时渲染格式化的 Markdown 输出。否则，增量文本会直接打印到标准输出。
+        *   流式处理中会捕获 `FinishReasonLength` 异常，这表明 LLM 的输出可能因为达到了其最大输出 token 限制而被提前截断。
+        *   在流式输出的每个更新点，会调用 `self.live_incremental_response()` 来更新屏幕上显示的（可能是 Markdown 格式的）内容。
+    *   **非流式输出 (`self.stream` 为 `False`)**:
+        *   `model.send_completion()` 会直接返回完整的响应对象。
+        *   `self.show_send_output(completion)` 负责处理这个完整响应，提取其中的文本内容、函数调用或推理内容，并将其存入相应的内部变量。然后一次性渲染完整的响应。
+    *   在 `send` 方法的 `finally` 块中，会记录完整的 LLM 响应内容，并确保 `self.partial_response_content` 中的推理标签（如 `<reasoning>...</reasoning>`）及其内容通过 `self.remove_reasoning_content()` 被移除，因为这部分内容仅供 Aider 内部或调试使用，不应视为最终用户输出或代码编辑的一部分。
+    *   此过程会捕获各类 `litellm` 抛出的异常 (如 `ContextWindowExceededError`, `APIError` 等) 和 `KeyboardInterrupt` (用户中断)。对于可重试的 API 错误，它包含了一个指数退避重试逻辑。
+
+6.  **处理 LLM 响应后**:
+    *   **显示用量报告 (`show_usage_report`)**:
+        *   调用 `self.calculate_and_show_tokens_and_cost()` 计算本次交互所消耗的 prompt token 和 completion token 数量，以及预估的费用（如果模型价格已知）。这些信息会显示给用户，并累加到会话的总 token 数和总费用中。
+    *   **更新消息列表**:
+        *   将 LLM 的最终回复 (无论是文本内容 `self.partial_response_content` 还是函数调用 `self.partial_response_function_call`) 包装成一个消息对象 `dict(role="assistant", ...)`，并追加到 `self.cur_messages` 中。
+    *   **处理上下文超限错误 (`show_exhausted_error`)**:
+        *   如果在调用 LLM 时捕获到 `ContextWindowExceededError`，或者发生了 `FinishReasonLength` 异常 (并且模型不支持通过 assistant prefill 继续生成)，则会调用此方法向用户显示详细的错误信息和减少 token 占用的建议。
+    *   **检查 LLM 回复中的文件提及**:
+        *   再次调用 `self.check_for_file_mentions()`，但这次是针对 LLM 的回复内容 `content`。如果 LLM 在其解释或代码中提及了新的、尚未被添加到聊天的文件名，Aider 会提示用户是否要将这些文件加入聊天。如果用户同意，这可能会改变聊天上下文，并通过设置 `self.reflected_message` 来通知 `run_one` 中的反思循环，以便让 LLM 在下一个回合中感知到这个上下文变化。
+    *   **应用代码更新 (`apply_updates`)**:
+        *   如果 LLM 的回复中包含了代码更改指令 (其具体格式和解析方式取决于当前 Coder 子类的实现，例如 `EditBlockCoder` 会寻找特定的编辑块格式)，则调用 `self.apply_updates()`。
+        *   `apply_updates` 内部会调用子类的 `get_edits()` 方法来从 LLM 响应中提取编辑指令，然后调用 `apply_edits()` 方法将这些更改实际应用到工作区的文件中。
+        *   如果 `self.auto_commits` (自动提交) 配置为 `True` 且代码被实际修改，`apply_updates` 成功后会触发一次 Git commit。
+    *   **自动 Lint (`auto_lint`)**:
+        *   如果在 `apply_updates` 中有文件被编辑过，并且 `self.auto_lint` (自动代码规范检查) 配置为 `True`，则会对所有被修改过的文件运行 linter。
+        *   如果 lint 检查发现任何错误，这些错误信息会被格式化并赋值给 `self.reflected_message`。这将触发 `run_one` 中的反思流程，让 LLM 在下一个回合中尝试修复这些 lint 错误。
+    *   **运行 Shell 命令 (`run_shell_commands`)**:
+        *   如果 LLM 在其响应中通过特定格式建议了应执行的 shell 命令 (这些命令会在解析编辑块时被收集到 `self.shell_commands` 列表中)，并且 `self.suggest_shell_commands` (允许执行LLM建议的shell命令) 配置为 `True`：
+            *   Aider 会向用户显示这些命令，并逐条询问是否执行。
+            *   如果用户同意执行，命令将在本地 shell 中运行。如果命令产生了输出，并且用户再次同意，该输出会被添加回聊天上下文，作为新的用户消息，可能会触发一次新的、基于该输出的对话轮次。
+    *   **自动测试 (`auto_test`)**:
+        *   如果在 `apply_updates` 中有文件被编辑过，并且 `self.auto_test` (自动测试) 配置为 `True`，则会运行用户在 `self.test_cmd` 中配置的测试命令。
+        *   如果测试命令执行后报告了任何测试失败，这些失败信息会被格式化并赋值给 `self.reflected_message`，同样触发反思流程，让 LLM 尝试修复导致测试失败的代码问题。
+    *   如果以上任何后处理步骤（如 lint 错误、测试失败、文件提及后用户同意添加文件）导致 `self.reflected_message` 被设置，那么在返回到 `run_one` 方法后，其内部的循环会继续，再次调用 `send_message`，并将 `self.reflected_message` 的内容作为新的用户输入发送给 LLM，以进行修正。
+
+## 应用代码更新 (`apply_updates`)
+
+当 LLM 的响应中包含代码修改指令时，`apply_updates` 方法负责协调从解析指令到实际将这些修改应用到文件系统中的整个过程。
+
+主要步骤如下：
+
+1.  **获取编辑指令 (`get_edits`)**:
+    *   调用 `self.get_edits()`。这是一个在 `BaseCoder` 中可能未完全实现（或提供默认空实现）的方法，需要由具体的 Coder 子类 (如 `EditBlockCoder`, `WholeFileCoder`, `DiffCoder` 等) 根据其特定的与 LLM 交互的编辑格式来重写。
+    *   该方法的核心职责是解析 `self.partial_response_content` (LLM的完整响应文本)，并将其转换为一个标准化的编辑指令列表。每条指令通常包含了目标文件名以及如何修改该文件的具体信息 (例如，对于 `EditBlockCoder`，是搜索内容和替换内容；对于 `WholeFileCoder`，是整个文件的原始内容和新内容)。
+    *   例如，在 `EditBlockCoder` 中，`get_edits()` 会调用 `find_original_update_blocks` 函数来查找并解析所有 `<<<<<<< SEARCH ... ======= ... >>>>>>> REPLACE` 格式的编辑块。
+
+2.  **预演编辑 (`apply_edits_dry_run`)**:
+    *   调用 `self.apply_edits_dry_run(edits)`，其中 `edits` 是上一步获取到的编辑指令列表。这个方法也通常由子类根据其编辑逻辑实现。
+    *   其目的是在不实际写入任何文件到磁盘的情况下，对编辑指令进行有效性检查、预处理或模拟应用。
+    *   例如，在 `EditBlockCoder` 中，`apply_edits_dry_run` 实际上会调用 `self.apply_edits(edits, dry_run=True)`，这意味着它会执行大部分与实际应用编辑相同的逻辑（如文件读取、内容搜索），但不进行最终的文件写入操作。这有助于提前发现潜在的匹配问题。
+
+3.  **准备编辑 (`prepare_to_edit`)**:
+    *   此方法负责在实际修改文件之前，确保所有待编辑的文件都处于合适的状态，并处理用户权限和工作区清洁度问题。
+    *   它会遍历经过预演（且可能被 `apply_edits_dry_run` 修改过的）编辑指令 `edits`：
+        *   对于每条编辑指令中指定的文件路径 `path`：
+            *   **权限检查 (`self.allowed_to_edit(path)`)**:
+                *   如果文件路径 `path` (解析为绝对路径 `full_path`) 不在 `self.abs_fnames` (当前聊天中已添加的文件集合) 中，Aider 会通过 `self.io.confirm_ask` 询问用户是否允许对这个未明确添加到聊天的文件进行编辑。
+                *   如果文件不存在：会询问用户是否允许创建新文件。如果用户同意且当前不是 `dry_run` (空运行) 模式，Aider 会尝试创建该文件，并且如果项目使用了 Git (`self.repo` 存在)，还会将这个新文件添加到 Git 的暂存区。新创建的文件会被加入到 `self.abs_fnames`。
+                *   检查文件是否被 Git LFS 追踪或被 `.aiderignore` 规则忽略，如果是，则可能跳过编辑。
+            *   **脏提交检查 (`self.check_for_dirty_commit(path)`)**:
+                *   如果上一步确认允许编辑该文件，并且 `self.dirty_commits` (允许为未提交的更改创建提交) 配置为 `True`，同时 `self.repo` 存在且文件 `path` 在 Git 中有未提交的本地更改 (即 `self.repo.is_dirty(path)` 为 `True`)：
+                    *   Aider 会将此文件路径添加到 `self.need_commit_before_edits` 集合中。这是为了确保 Aider 的编辑是基于一个已知的、干净的文件版本之上，避免与用户的本地未暂存/未提交的更改混淆或冲突。
+    *   在遍历完所有编辑指令并收集了所有需要预先提交的“脏”文件后，调用 `self.dirty_commit()`。此方法会检查 `self.need_commit_before_edits` 集合，如果非空，它会为这些文件创建一个或多个 Git commit，消息通常指明这是为 Aider 编辑所做的预备提交。
+
+4.  **实际应用编辑 (`apply_edits`)**:
+    *   在 `prepare_to_edit` 确保了工作区状态后，如果当前不是 `dry_run` 模式：
+        *   调用 `self.apply_edits(edits)` (注意：这里的 `edits` 是经过 `apply_edits_dry_run` 和 `prepare_to_edit` 可能修改过的版本)。这同样是一个通常由 Coder 子类实现的方法，负责将编辑指令实际写入文件系统。
+        *   例如，`EditBlockCoder` 的 `apply_edits` 方法会遍历指令，读取每个文件的原始内容，执行搜索和替换操作，然后将修改后的内容写回文件。
+    *   此步骤会记录所有被成功编辑的文件路径到局部变量 `edited` 集合中。
+
+5.  **处理结果与异常**:
+    *   如果在 `get_edits`, `apply_edits_dry_run`, 或 `apply_edits` 的过程中发生 `ValueError` (这通常表示 LLM 生成的编辑指令格式不正确，导致解析或应用失败) 或其他类型的异常 (如 Git 相关错误、文件系统读写错误)：
+        *   这些异常会被捕获。
+        *   通过 `self.io.tool_error()` 向用户显示具体的错误信息。
+        *   关键地，捕获到的错误信息（或者一个引导 LLM 修正的提示）通常会被赋值给 `self.reflected_message`。这会使得在返回到 `run_one` 方法后，触发其内部的反思循环，让 LLM 看到这个错误并尝试生成修正后的编辑指令。
+    *   如果编辑过程（即使是 `dry_run`）顺利完成（可能部分文件编辑成功，部分失败，但没有抛出中断流程的异常），对于每个成功编辑的文件路径 `path`，会通过 `self.io.tool_output()` 告知用户 "Applied edit to {path}"。如果是 `dry_run` 模式，则告知 "Did not apply edit to {path} (--dry-run)"。
+
+6.  **返回结果**:
+    *   `apply_updates` 方法最终返回在第四步中收集到的、被成功编辑（或在 `dry_run` 模式下模拟编辑）的文件路径的集合 `edited`。这个集合非常重要，因为它会被 `send_message` 方法的后续步骤使用，例如：
+        *   传递给 `auto_commit` 方法，以决定哪些文件应该包含在由 Aider 生成的 Git commit 中。
+        *   用于确定哪些文件需要进行自动 lint (`auto_lint`)。
+        *   用于确定是否需要运行自动测试 (`auto_test`)，因为代码已更改。
+
+## `EditBlockCoder` 特有实现
+
+`EditBlockCoder` 是 `BaseCoder` 的一个具体子类，它使用一种基于“搜索/替换块”（Search/Replace Block）的特定文本格式与 LLM 交互，指示 LLM如何修改代码。这是 Aider 中最常用的代码编辑方式之一。
+
+### 编辑格式 (`edit_format`)
+
+*   `EditBlockCoder.edit_format` 属性被设置为字符串 `"diff"`。值得注意的是，虽然名为 "diff"，其历史实现和核心机制更接近于“搜索并替换”而非传统的 `diff -u` 格式。此名称主要用于在系统中区分它与其他编辑格式（如 `whole` 代表完整文件内容替换，或 `udiff` 代表统一差异格式）。
+*   它依赖于 `aider.coders.editblock_prompts.EditBlockPrompts` 类中定义的特定提示语。这些提示会明确指导 LLM 以“搜索/替换块”的形式提供其建议的代码更改。
+
+### 获取编辑指令 (`get_edits`)
+
+*   此方法重写了 `BaseCoder.get_edits`，以适应其特定的编辑块格式。
+*   它负责解析 `self.partial_response_content` (即 LLM 返回的完整响应文本)。
+*   **查找编辑块**:
+    *   核心功能是调用 `aider.coders.editblock.find_original_update_blocks(self.partial_response_content)` 函数。
+    *   `find_original_update_blocks` 使用正则表达式来查找并解析符合以下基本结构的文本块：
+      ```text
+      path/to/filename.ext
+      <<<<<<< SEARCH
+      # 要在文件中搜索的原始内容片段
+      # 可能有多行
+      =======
+      # 用于替换上述原始内容的新内容片段
+      # 可能有多行
+      >>>>>>> REPLACE
+      ```
+    *   在这些 `SEARCH/REPLACE` 块之前，通常会有一行纯文本指定目标文件名（如 `path/to/filename.ext`）。`find_original_update_blocks` 会尝试解析这个文件名，并将其与每个编辑块关联起来。
+*   **处理 Shell 命令**:
+    *   在解析编辑块的过程中，如果 LLM 的响应中包含形如 ` ```bash ... ``` ` (或其他语言标识符) 的代码块，并且这些代码块 *不直接属于* 某个 `SEARCH` 或 `REPLACE` 部分内部（即它们是独立的、顶级的代码块），那么这些通常被视为 LLM 建议执行的 shell 命令。
+    *   这些被识别出的 shell 命令块的内容会被提取出来，并追加到 `self.shell_commands` 列表中。这些命令后续会由 `BaseCoder.run_shell_commands` 方法处理（提示用户是否执行）。
+*   最终，`get_edits` 返回一个编辑指令的列表。列表中的每个元素是一个元组，格式为 `(file_path, original_text, updated_text)`，其中：
+    *   `file_path` 是从编辑块前解析出的文件名。
+    *   `original_text` 是 `SEARCH` 块中的内容。
+    *   `updated_text` 是 `REPLACE` 块中的内容。
+
+### 应用编辑的预演 (`apply_edits_dry_run`)
+
+*   此方法在 `EditBlockCoder` 中的实现非常直接：它简单地调用 `self.apply_edits(edits, dry_run=True)`。
+*   这意味着预演逻辑与实际应用编辑的逻辑大部分是共享的，只是在最后的文件写入步骤上有所不同。通过设置 `dry_run=True`，可以执行所有匹配和替换的计算，而无需修改磁盘上的文件。
+
+### 应用编辑 (`apply_edits`)
+
+*   此方法重写了 `BaseCoder.apply_edits`，包含了将 `SEARCH/REPLACE` 块应用到文件的核心逻辑。
+*   它会遍历从 `get_edits`（或 `apply_edits_dry_run`）接收到的编辑指令列表：
+    *   对于每一个 `(path, original, updated)` 指令：
+        *   获取文件的绝对路径 `full_path = self.abs_root_path(path)`。
+        *   读取文件的当前内容 `content = self.io.read_text(full_path)`。
+        *   调用 `aider.coders.editblock.do_replace(full_path, content, original, updated, self.fence)` 函数来尝试应用单个编辑块。
+            *   **清理包装 (`strip_quoted_wrapping`)**: 在 `do_replace` 内部，首先会对 `original` 和 `updated` 文本进行清理。这包括移除 LLM 有时会错误添加在 `SEARCH` 或 `REPLACE` 内容前后的文件名和代码围栏（如 ` ```python ... ``` `）。
+            *   **新文件创建**: 如果 `original` 文本为空或只包含空白字符，并且目标文件 `full_path` 当前不存在，则此编辑块被视为一个新文件创建操作。此时，`updated` 文本的内容将作为新文件的全部内容。
+            *   **内容替换 (`replace_most_similar_chunk`)**: 如果不是创建新文件，则调用 `replace_most_similar_chunk` 来在文件 `content` 中找到与 `original` 文本最匹配的部分，并将其替换为 `updated` 文本。这个匹配过程有多个策略：
+                1.  **精确匹配优先**: 首先尝试在文件内容中进行精确的、逐字符的 `original` 文本匹配。
+                2.  **忽略前导空格匹配**: 如果精确匹配失败，会尝试移除 `original` 文本每行的共同前导空格，然后再次进行匹配。这有助于处理 LLM 在生成 `SEARCH` 块时可能引入的缩进不一致问题。
+                3.  **省略号 (`...`) 处理 (`try_dotdotdots`)**: 如果 `original` 文本中包含 `...` (通常表示 LLM 省略了部分未改变的代码)，`try_dotdotdots` 会尝试将 `original` 分割成 `...` 上下的两部分，分别匹配这两部分，并确保它们在文件中有合理的相对位置。
+                4.  **模糊匹配 (Edit Distance)**: 作为最后的、通常被注释掉或有高相似度要求的尝试，代码中曾包含（或可以配置）使用 Python 的 `difflib.SequenceMatcher` 来寻找与 `original` 最相似的代码块进行替换。这是一种更宽松的匹配，但需要小心使用以避免错误替换。
+            *   `do_replace` 返回修改后的完整文件内容 `new_content`，如果替换成功；或者返回 `None`，如果无法匹配或应用替换。
+        *   **失败重试机制**: 如果在一个文件中应用编辑块失败 (`new_content` 为 `None`)，并且 `original` 文本并非旨在创建新文件的空内容，`EditBlockCoder` 有一个特殊的重试逻辑：它会尝试在聊天中已添加的 *其他* 文件 (`self.abs_fnames` 中除了当前 `path` 之外的文件) 中匹配并应用这个 `original/updated` 编辑块。如果这个编辑块在另一个文件中成功匹配并应用，那么该编辑指令的 `path` 字段会被更新为那个实际被修改的文件名。这个机制试图纠正 LLM 可能错误地将编辑块归属到错误文件的情况。
+        *   如果是在 `dry_run` 模式下，即使匹配成功，也不会实际写入文件，`io.write_text()` 会被跳过。
+    *   **错误处理与收集**:
+        *   如果在遍历所有编辑指令后，存在任何一个 `do_replace` 调用返回了 `None` (表示该编辑块匹配和替换失败)，那么这个编辑指令会被记录为失败。
+        *   如果存在至少一个失败的编辑指令，`apply_edits` 方法会构造一个详细的错误消息字符串。此消息会包含所有失败的编辑块的 `SEARCH` 内容、它们原先尝试匹配的文件名，以及一些有助于用户或 LLM 理解失败原因的提示 (例如，如果发现 `REPLACE` 部分的内容其实已经存在于文件中，或者建议用户仔细检查 `SEARCH` 块是否与文件内容完全精确匹配)。
+        *   这个聚合的错误消息最终会通过 `ValueError(err_msg)` 抛出。这个 `ValueError` 通常会被 `BaseCoder.apply_updates` 方法捕获，然后其内容会被设置到 `self.reflected_message`。这就触发了 Aider 的“反思”机制：在下一轮与 LLM 的交互中，这个错误信息会作为输入的一部分发送给 LLM，提示它修正之前生成的、导致错误的编辑块。
+    *   如果所有编辑指令都成功应用（或者是在 `dry_run` 模式下所有指令都成功模拟应用），则方法正常返回，不抛出异常。
+
+通过这种方式，`EditBlockCoder` 实现了一种相对健壮的、基于文本模式匹配和替换的代码编辑方法，并结合了错误反馈和反思机制来提高 LLM 代码修改的成功率。


### PR DESCRIPTION
This commit introduces a new markdown file `coder_execution_flow_zh.md` which provides a detailed explanation of the execution process of the `Coder` class and its `EditBlockCoder` subclass.

The documentation covers:
- Initialization of the Coder class.
- The main execution loop for your interaction.
- Processing of single messages, including preprocessing and reflection.
- Sending messages to the LLM, context assembly, and response handling.
- Application of code updates received from the LLM.
- Specific implementation details of `EditBlockCoder` for parsing and applying search/replace edits.